### PR TITLE
Typo fixed: boid -> void

### DIFF
--- a/en/reference/rdkafka/rdkafka/kafkaconsumer/commitasync.xml
+++ b/en/reference/rdkafka/rdkafka/kafkaconsumer/commitasync.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>boid</type><methodname>RdKafka\KafkaConsumer::commitAsync</methodname>
+   <modifier>public</modifier> <type>void</type><methodname>RdKafka\KafkaConsumer::commitAsync</methodname>
    <methodparam choice="opt"><type>string</type><parameter>message_or_offsets</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>


### PR DESCRIPTION
Hi @arnaud-lb 

Quick fix for the typo in docs. Thanks!