### PR TITLE
add docker-compose, apache for doc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3.4-cli-stretch
+FROM php:7.3-apache
 
 RUN apt-get install bash
 
@@ -6,4 +6,4 @@ RUN pear install doc.php.net/PhD && pear install doc.php.net/PhD_PHP
 
 WORKDIR /php-rdkafka-doc
 
-ENTRYPOINT ./build.sh
+ENTRYPOINT ./entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ The documentation can be read at https://arnaud-lb.github.io/php-rdkafka/phpdoc/
 
 ## Building documentation
 
-- Install docker
-- Run ``make``
-- The output is placed in ``./output/php-chunked-xhtml``
+- Install [docker](https://docs.docker.com/install/) and [docker-compose](https://docs.docker.com/compose/install/)
+- Run docker-compose up
+- Visit http://localhost:8081 to see the compiled version of the documentation
+
+Note: to rebuild the documentation and see changes you made, run:
+```
+docker-compose exec apache ./build.sh
+```
+This will be done on startup as well
 
 This is a stripped-down version of the PHP documentation that can be found here:
 https://svn.php.net/viewvc/phpdoc/. The goal would be to merge it there

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# svn co http://svn.php.net/repository/phpdoc/modules/doc-en
-# pear install doc.php.net/phd
-# pear install doc.php.net/phd_php
-# cd doc-en
+#copy current doc to not mess up files that have replacement mechanisms
+rm -rf /doc
+cp -R /php-rdkafka-doc /doc
+cd /doc
 
 # Set the path to PHP from environment or use which to discover it
 if [ "$PHP" == "" ];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.1'
+services:
+  apache:
+    build:
+      context: .
+    volumes:
+      - ./:/php-rdkafka-doc
+    ports:
+      - "8081:80"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+./build.sh
+chgrp -R www-data /doc
+rm -rf /var/www/html
+ln -s /doc/output/php-chunked-xhtml /var/www/html
+apache2-foreground

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
+
+#build the doc
 ./build.sh
+
+#change permissions for apache
 chgrp -R www-data /doc
+
+#symlink the generated doc
 rm -rf /var/www/html
 ln -s /doc/output/php-chunked-xhtml /var/www/html
+
 apache2-foreground


### PR DESCRIPTION
I noticed that the build messes up my file-entities.ent and file-entities.php because it replaces some paths.
So in the container i copy it, to not mess up stuff (so we wont commit replaced stuff)
And added an apache, to see the doc that we have in docker