### PR TITLE
remove deprecated configuration options

### DIFF
--- a/en/reference/rdkafka/examples/low-level-consumer/at-least-once.xml
+++ b/en/reference/rdkafka/examples/low-level-consumer/at-least-once.xml
@@ -9,9 +9,6 @@
 <![CDATA[
 <?php
 
-// Disable committing offsets automatically
-$topicConf->set('auto.commit.enable', 'false');
-
 $topic = $rk->newTopic("test", $topicConf);
 
 // ...

--- a/en/reference/rdkafka/examples/low-level-consumer/basic.xml
+++ b/en/reference/rdkafka/examples/low-level-consumer/basic.xml
@@ -20,11 +20,10 @@ $topicConf = new RdKafka\TopicConf();
 $topicConf->set('auto.commit.interval.ms', 100);
 
 // Set the offset store method to 'file'
-$topicConf->set('offset.store.method', 'file');
-$topicConf->set('offset.store.path', sys_get_temp_dir());
+$topicConf->set('offset.store.method', 'broker');
 
-// Alternatively, set the offset store method to 'broker'
-// $topicConf->set('offset.store.method', 'broker');
+// Alternatively, set the offset store method to 'none'
+// $topicConf->set('offset.store.method', 'none');
 
 // Set where to start consuming messages when there is no initial offset in
 // offset store or the desired offset is out of range.

--- a/en/reference/rdkafka/rdkafka/kafkaconsumertopic/offsetstore.xml
+++ b/en/reference/rdkafka/rdkafka/kafkaconsumertopic/offsetstore.xml
@@ -17,11 +17,6 @@
   <para>
    Store offset <parameter>offset</parameter> for topic partition <parameter>partition</parameter>. The offset will be commited (written) to the offset store according to <code>auto.commit.interval.ms</code>.
   </para>
-  <note>
-   <para>
-    <code>auto.commit.enable</code> must be set to <code>false</code> when using this API.
-   </para>
-  </note>
 
  </refsect1>
 


### PR DESCRIPTION
I removed config options (or updated) from the doc, that are deprecated as of librdkafka 1.0