### PR TITLE
Update `librdkafka.dll` correct installation path

### DIFF
--- a/en/reference/rdkafka/configure.xml
+++ b/en/reference/rdkafka/configure.xml
@@ -38,7 +38,7 @@ extension=rdkafka.so
    Precompiled binaries for each release are available from
    <link xlink:href="&url.pecl.package;rdkafka">PECL</link> for a variety of
    combinations of versions, thread safety, and VC libraries. Extract the
-   archive and put the <filename>php_rdkfaka.dll</filename> and <filename>librdkafka.dll</filename> files in your PHP extension
+   archive and put <filename>librdkafka.dll</filename> in the root PHP directory (same level as php.exe) and the <filename>php_rdkfaka.dll</filename> file in your PHP extension
    directory ("ext" by default).
   </para>
   <note>


### PR DESCRIPTION
Documentation wrongly states `librdkafka.dll` should stay in the `ext` folder instead of the root PHP folder, next to `php.exe`.

Have been bitten by this a number of times but enough is enough :-)

Also, others reported this:
- https://github.com/arnaud-lb/php-rdkafka/issues/159#issuecomment-437391379