### PR TITLE
Use auto.offset.reset earliest instead of smallest

### DIFF
--- a/en/reference/rdkafka/examples/high-level-consumer.xml
+++ b/en/reference/rdkafka/examples/high-level-consumer.xml
@@ -39,8 +39,8 @@ $conf->set('metadata.broker.list', '127.0.0.1');
 
 // Set where to start consuming messages when there is no initial offset in
 // offset store or the desired offset is out of range.
-// 'smallest': start from the beginning
-$conf->set('auto.offset.reset', 'smallest');
+// 'earliest': start from the beginning
+$conf->set('auto.offset.reset', 'earliest');
 
 $consumer = new RdKafka\KafkaConsumer($conf);
 

--- a/en/reference/rdkafka/examples/low-level-consumer/basic.xml
+++ b/en/reference/rdkafka/examples/low-level-consumer/basic.xml
@@ -27,8 +27,8 @@ $topicConf->set('offset.store.method', 'broker');
 
 // Set where to start consuming messages when there is no initial offset in
 // offset store or the desired offset is out of range.
-// 'smallest': start from the beginning
-$topicConf->set('auto.offset.reset', 'smallest');
+// 'earliest': start from the beginning
+$topicConf->set('auto.offset.reset', 'earliest');
 
 $topic = $rk->newTopic("test", $topicConf);
 


### PR DESCRIPTION
Hello,

From the Kafka doc, "smallest" does not exist. It seems it's been deprecated and replaced by "earliest"