### PR TITLE
Variable name fix in getcommittedoffsets.xml 

### DIFF
--- a/en/reference/rdkafka/rdkafka/kafkaconsumer/getcommittedoffsets.xml
+++ b/en/reference/rdkafka/rdkafka/kafkaconsumer/getcommittedoffsets.xml
@@ -62,7 +62,7 @@ $kafkaConsumer = new RdKafka\KafkaConsumer($conf);
 $topicPartition = new TopicPartition('myTopic', 0);
 $timeoutMs = 10000000;
 
-$topicPartitionsWithOffsets = $consumer->getCommittedOffsets([$topicPartition], $timeoutMs));
+$topicPartitionsWithOffsets = $kafkaConsumer->getCommittedOffsets([$topicPartition], $timeoutMs));
 ?>
 ]]>
             </programlisting>


### PR DESCRIPTION
Fixing the variable name from `$consumer` to `$kafkaConsumer` as there is no variable called `$consumer` in the example here.

Fixes #52 