### PR TITLE
Variable name fix in getoffsetpositions.xml

### DIFF
--- a/en/reference/rdkafka/rdkafka/kafkaconsumer/getoffsetpositions.xml
+++ b/en/reference/rdkafka/rdkafka/kafkaconsumer/getoffsetpositions.xml
@@ -55,7 +55,7 @@ $kafkaConsumer = new RdKafka\KafkaConsumer($conf);
 $topicPartition = new TopicPartition('myTopic', 0);
 $timeoutMs = 10000000;
 
-$topicPartitionsWithOffsets = $consumer->getOffsetPositions([$topicPartition]));
+$topicPartitionsWithOffsets = $kafkaConsumer->getOffsetPositions([$topicPartition]));
 ?>
 ]]>
             </programlisting>


### PR DESCRIPTION
Fixing the variable name from `$consumer` to `$kafkaConsumer` as there is no variable called `$consumer` in the example here.

Fixes #52 