### PR TITLE
Incorrect constant name for partitioner

### DIFF
--- a/en/reference/rdkafka/constants.xml
+++ b/en/reference/rdkafka/constants.xml
@@ -882,7 +882,7 @@
    </varlistentry>
    <varlistentry xml:id="constant.rd-kafka-msg-partitioner-murmur2-random">
     <term>
-     <constant>RD_KAFKA_MSG_PARTITIONER_CONSISTENT</constant>
+     <constant>RD_KAFKA_MSG_PARTITIONER_MURMUR2_RANDOM</constant>
      (<type>integer</type>)
     </term>
     <listitem>


### PR DESCRIPTION
I found this while going through the docs.