### PR TITLE
Set `enable.partition.eof` to `true` in all examples handling `RD_KAFKA_RESP_ERR__PARTITION_EOF`

### DIFF
--- a/en/reference/rdkafka/example.php
+++ b/en/reference/rdkafka/example.php
@@ -11,6 +11,9 @@ $conf->set('group.id', 'myConsumerGroup');
 // Initial list of Kafka brokers
 $conf->set('metadata.broker.list', '127.0.0.1:9093');
 
+// Emit EOF event when reaching the end of a partition
+$conf->set('enable.partition.eof', 'true');
+
 $conf->setRebalanceCb(function ($rk, $err, $partitions) {
     var_dump(rd_kafka_err2str($err), $partitions);
     switch ($err) {

--- a/en/reference/rdkafka/examples/high-level-consumer.xml
+++ b/en/reference/rdkafka/examples/high-level-consumer.xml
@@ -42,6 +42,9 @@ $conf->set('metadata.broker.list', '127.0.0.1');
 // 'earliest': start from the beginning
 $conf->set('auto.offset.reset', 'earliest');
 
+// Emit EOF event when reaching the end of a partition
+$conf->set('enable.partition.eof', 'true');
+
 $consumer = new RdKafka\KafkaConsumer($conf);
 
 // Subscribe to topic 'test'

--- a/en/reference/rdkafka/examples/low-level-consumer/basic.xml
+++ b/en/reference/rdkafka/examples/low-level-consumer/basic.xml
@@ -13,6 +13,9 @@ $conf = new RdKafka\Conf();
 // Set the group id. This is required when storing offsets on the broker
 $conf->set('group.id', 'myConsumerGroup');
 
+// Emit EOF event when reaching the end of a partition
+$conf->set('enable.partition.eof', 'true');
+
 $rk = new RdKafka\Consumer($conf);
 $rk->addBrokers("127.0.0.1");
 


### PR DESCRIPTION
I overlooked this in the config at https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md and it took me forever to find out why my consumer was timing out instead of reaching EOF. Therefore I thought that it makes sense to adapt it here as well. Otherwise the `RD_KAFKA_RESP_ERR__PARTITION_EOF` would be basically dead code.